### PR TITLE
added config_file option for specifying jasmine config file

### DIFF
--- a/lib/middleman/jasmine/extension.rb
+++ b/lib/middleman/jasmine/extension.rb
@@ -19,7 +19,7 @@ module Middleman
         app.map("/#{options.fixtures_dir}") { run Rack::Directory.new(options.fixtures_dir) }
 
         app.after_configuration do
-          ::JasmineSprocketsProxy.configure(sprockets)
+          ::JasmineSprocketsProxy.configure(sprockets, options.config_file)
         end
       end
 
@@ -34,7 +34,8 @@ module Middleman
       def default_options
         {
           jasmine_url: "/jasmine",
-          fixtures_dir: "spec/javascripts/fixtures"
+          fixtures_dir: "spec/javascripts/fixtures",
+          config_file: nil
         }        
       end      
     alias :included :registered

--- a/lib/middleman/jasmine/jasmine_sprockets_proxy.rb
+++ b/lib/middleman/jasmine/jasmine_sprockets_proxy.rb
@@ -10,8 +10,8 @@ class JasmineSprocketsProxy
       @@sprockets_app
     end
 
-    def configure(middleman_sprockets)
-      Jasmine.load_configuration_from_yaml
+    def configure(middleman_sprockets, config_file = nil)
+      Jasmine.load_configuration_from_yaml(config_file)
       @@jasmine_app   = Jasmine::Application.app(Jasmine.config)
       @@sprockets_app = 
         if defined?(::Sprockets::Environment)


### PR DESCRIPTION
I see there was a previous pull request for this feature but it was closed. I've been using this locally for a bit and it's been pretty useful for the reasons described in pull request #2. It's also nice to be able to relocate your jasmine.yml (I set mine up as spec/config.yml and completely delete the support folder).
