### PR TITLE
Fixes to work with latest Middleman

### DIFF
--- a/lib/middleman/jasmine/tasks.rb
+++ b/lib/middleman/jasmine/tasks.rb
@@ -1,4 +1,5 @@
 require 'middleman/rack'
+require 'logger'
 
 require 'json'
 require 'jasmine'
@@ -11,7 +12,8 @@ namespace :middleman_jasmine do
     config       = Jasmine.config
     logger       = Logger.new($stdout)
     logger.level = Logger::WARN
-    server       = Rack::Server.new(:app => Middleman.server, :Port => config.port(:ci), :AccessLog => [], :Logger => logger)
+    middleman_app = ::Middleman::Application.server
+    server       = Rack::Server.new(:app => middleman_app, :Port => config.port(:ci), :AccessLog => [], :Logger => logger)
 
     t = Thread.new do
       begin
@@ -29,7 +31,7 @@ namespace :middleman_jasmine do
     exit_code_formatter = Jasmine::Formatters::ExitCode.new
     formatters << exit_code_formatter
 
-    middleman_extensions = ::Middleman::Application.server.inst.extensions
+    middleman_extensions = middleman_app.inst.extensions
     throw "Middleman Jasmine extension not activated" unless middleman_extensions.has_key?(:jasmine)
 
     path   = middleman_extensions[:jasmine].jasmine_url


### PR DESCRIPTION
* Refer to `Middleman::Application.server` instead of `Middlman.server`

  `Middleman.server` no longer exists

* Only call Middleman::Application.server once

  Middleman does not memoize the result of `server`, so it reconfigures the application every time `server` is called. This results in `JasmineSprocketsProxy.configure` being called twice and two `DebugAssetMapper` path mappers being added to the Jasmine config.

* add `require 'logger'`

  `middleman_jasmine:ci` errors because `Logger` is not defined.